### PR TITLE
Fix #1: Add quick start example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,56 @@
 
 A command-line tool that automates GitHub issue resolution using Claude Code in isolated Docker containers. Handles complete workflow from issue analysis to pull request creation with intelligent labeling and linking.
 
+## 🏃 Quick Start Example
+
+Get started in minutes with this simple example:
+
+### 1. Install Prerequisites
+```bash
+# Ensure you have Go, Docker, and Git installed
+go version    # Should show Go 1.23+
+docker --version
+git --version
+```
+
+### 2. Build the CLI
+```bash
+git clone https://github.com/your-username/claude-code-background-agent
+cd claude-code-background-agent
+go build -o claudecli
+```
+
+### 3. Set Environment Variables
+```bash
+export GITHUB_TOKEN="your_github_personal_access_token"
+export ANTHROPIC_API_KEY="your_anthropic_api_key"
+export REPO_OWNER="your-username"
+export REPO_NAME="your-repository"
+```
+
+### 4. Process Your First Issue
+```bash
+# Authenticate with GitHub
+./claudecli auth login
+
+# Process issue #42 and create a pull request automatically
+./claudecli issue 42
+```
+
+### Expected Output
+```
+Processing issue #42 for your-username/your-repository
+Fetching issue #42 from your-username/your-repository...
+Processing issue: Fix broken navigation menu
+Creating Docker container...
+Executing Claude Code...
+Claude Code execution completed successfully
+Creating pull request...
+✅ Successfully created pull request: https://github.com/your-username/your-repository/pull/43
+```
+
+That's it! The tool will automatically analyze the issue, make the necessary code changes using Claude Code, and create a pull request for review.
+
 ## 🚀 Current Status: Milestone 4 Complete
 
 **Latest Achievement**: Full GitHub PR creation & label management with complete issue-to-PR workflow automation.


### PR DESCRIPTION
## 🔧 Automated Fix for Issue #1

**Original Issue:** Add quick start example to README

### Issue Description
> ## Description
> 
> The README.md file is comprehensive but could benefit from a simple quick start example that shows users how to get started immediately.
> 
> ## Suggested Changes
> 
> Add a 'Quick Start Example' section near the top of the README that includes:
> - Basic installation steps
> - Simple example command
> - Expected output
> 
> ## Acceptance Criteria
> 
> - [ ] Add Quick Start Example section to README.md
> - [ ] Include installation commands
> - [ ] Show sample usage
> - [ ] Keep it concise and beginner-friendly
> 
> This is a simple documentation enhancement.

### Changes Made
This pull request was generated automatically by Claude Code to address the issue described above. The changes have been analyzed and implemented to resolve the reported problem.

### Review Notes
- 🤖 This PR was created by Claude Code Background Agent
- 📋 Please review the changes carefully before merging
- 🧪 Test the changes in your development environment
- 🔍 Verify that the original issue is resolved

Closes #1